### PR TITLE
Alan wip

### DIFF
--- a/python/geneditid/finder.py
+++ b/python/geneditid/finder.py
@@ -1,4 +1,5 @@
 import os
+import requests
 import logging
 
 from geneditid.config import cfg
@@ -64,17 +65,29 @@ class AmpliconFinder():
             primer_loc = sequence.find(primer_seq)
         return primer_loc, primer_seq
 
-
+    def _get_seq_ensembl_rest_api(self, chr:str, start:int, end:int) -> str:
+        # https://rest.ensembl.org/documentation/info/sequence_region
+        # https://rest.ensembl.org/sequence/region/human/1:10011..12211:1?content-type=text/plain
+        server = "https://rest.ensembl.org"
+        ext = f"/sequence/region/human/{chr}:{start}..{end}:1?"
+        
+        seq = requests.get(server+ext, headers={ "Content-Type" : "text/plain"})
+        return seq
+ 
     def find_amplicon_sequence(self, refgenome, amplicon_name, guide_loc, chr, fprimer_seq, rprimer_seq):
         self.log.info("Search amplicon sequence +/- 1000bp around guide location {} on chrom {}".format(guide_loc, chr))
         start = guide_loc - 1100
         end = guide_loc + 1100
+        seq_api = self._get_seq_ensembl_rest_api(chr, start, end)
         if os.path.exists(refgenome + '.fai'):
             self.log.info('fai file for {} already exists, there is no need to rebuild indexes'.format(refgenome))
             sequence = Fasta(refgenome, rebuild=False, build_index=False, read_ahead=10000)['{}'.format(chr)][start:end].seq
         else:
             self.log.info('fai file for {} do not exist, it will take a while to generate it'.format(refgenome))
             sequence = Fasta(refgenome, read_ahead=10000)['{}'.format(chr)][start:end].seq
+        if not seq_api.ok:
+            self.log.error('Ensembl REST API failed')
+        assert sequence in seq_api.text
         self.log.info(sequence)
         submitted_fprimer_seq = fprimer_seq
         submitted_rprimer_seq = rprimer_seq
@@ -151,5 +164,5 @@ class AmpliconFinder():
                     self.log.error('Target name\t{}'.format(amplicon['target_name']))
                     self.log.error(e)
                     self.log.error('---')
-                    raise FinderException('Unexpected error for Amplicon {} on target {}'.format(mplicon['name'], amplicon['target_name']))
+                    raise FinderException('Unexpected error for Amplicon {} on target {}'.format(amplicon['name'], amplicon['target_name']))
         self.log.info('{} created'.format(self.config_file))

--- a/python/geneditid/finder.py
+++ b/python/geneditid/finder.py
@@ -65,29 +65,31 @@ class AmpliconFinder():
             primer_loc = sequence.find(primer_seq)
         return primer_loc, primer_seq
 
-    def _get_seq_ensembl_rest_api(self, chr:str, start:int, end:int) -> str:
+    def _get_seq_ensembl_rest_api(self, chr:str, start:int, end:int, species:str = 'human') -> str:
         # https://rest.ensembl.org/documentation/info/sequence_region
         # https://rest.ensembl.org/sequence/region/human/1:10011..12211:1?content-type=text/plain
+        # https://grch37.rest.ensembl.org/sequence/region/human/1:10011..12211:1?content-type=text/plain
+
         server = "https://rest.ensembl.org"
-        ext = f"/sequence/region/human/{chr}:{start}..{end}:1?"
-        
+        ext = f"/sequence/region/{species}/{chr}:{start}..{end}:1?"        
         seq = requests.get(server+ext, headers={ "Content-Type" : "text/plain"})
         return seq
  
     def find_amplicon_sequence(self, refgenome, amplicon_name, guide_loc, chr, fprimer_seq, rprimer_seq):
         self.log.info("Search amplicon sequence +/- 1000bp around guide location {} on chrom {}".format(guide_loc, chr))
-        start = guide_loc - 1100
+        start = guide_loc - 1100 + 1
         end = guide_loc + 1100
         seq_api = self._get_seq_ensembl_rest_api(chr, start, end)
-        if os.path.exists(refgenome + '.fai'):
-            self.log.info('fai file for {} already exists, there is no need to rebuild indexes'.format(refgenome))
-            sequence = Fasta(refgenome, rebuild=False, build_index=False, read_ahead=10000)['{}'.format(chr)][start:end].seq
-        else:
-            self.log.info('fai file for {} do not exist, it will take a while to generate it'.format(refgenome))
-            sequence = Fasta(refgenome, read_ahead=10000)['{}'.format(chr)][start:end].seq
+        # if os.path.exists(refgenome + '.fai'):
+        #     self.log.info('fai file for {} already exists, there is no need to rebuild indexes'.format(refgenome))
+        #     sequence = Fasta(refgenome, rebuild=False, build_index=False, read_ahead=10000)['{}'.format(chr)][start:end].seq
+        # else:
+        #     self.log.info('fai file for {} do not exist, it will take a while to generate it'.format(refgenome))
+        #     sequence = Fasta(refgenome, read_ahead=10000)['{}'.format(chr)][start:end].seq
         if not seq_api.ok:
             self.log.error('Ensembl REST API failed')
-        assert sequence in seq_api.text
+        # assert sequence in seq_api.text
+        sequence = seq_api.text
         self.log.info(sequence)
         submitted_fprimer_seq = fprimer_seq
         submitted_rprimer_seq = rprimer_seq

--- a/scripts/setup_geneditid.sh
+++ b/scripts/setup_geneditid.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #BASEDIR=$(dirname "$0")/..
 BASEDIR="$( cd "$(dirname "$0")" ; pwd -P )"/..
 cd $BASEDIR
@@ -23,5 +24,5 @@ pyensembl install --release 95 --species homo_sapiens
 
 echo 'Create symlink to template file for accessing it from the WebApp'
 cd python/geneditidapp/static/
-ln -s ../../../data/templates/GEPXXXXX.xlsx
+ln -vfs ../../../data/templates/GEPXXXXX.xlsx
 cd $BASEDIR


### PR DESCRIPTION
Make use of the Ensembl REST API instead of having the reference genomes on disk.
Not using xrefs like previously tested back in 2020
https://github.com/GenEditID/GenEditID/commit/69e79c61b34587686f0858c922b701f6f00f98d1
but using seq that should be more robust